### PR TITLE
fix/CI 단계 테스트 실패로 인한 MySQL 이미지 경량화와 waitingFor() 도입

### DIFF
--- a/src/test/java/com/gachon/home_protector/IntegrationTestSupport.java
+++ b/src/test/java/com/gachon/home_protector/IntegrationTestSupport.java
@@ -6,13 +6,14 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 @ActiveProfiles("test")
 @SpringBootTest
 public abstract class IntegrationTestSupport {
 
-    private static final String MYSQL_VERSION = "mysql:latest";
+    private static final String MYSQL_VERSION = "alpine/mysql:latest";
     private static final String REDIS_VERSION = "redis:latest";
 
     private static final MySQLContainer<?> mySQL;
@@ -21,7 +22,8 @@ public abstract class IntegrationTestSupport {
     public static final int REDIS_PORT = 6379;
 
     static {
-        mySQL = new MySQLContainer<>(MYSQL_VERSION);
+        mySQL = new MySQLContainer<>(MYSQL_VERSION).waitingFor(Wait.forListeningPort());
+
         Redis = new GenericContainer(DockerImageName.parse(REDIS_VERSION))
                 .withExposedPorts(REDIS_PORT)
                 .withReuse(true);


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용


---

## 🔗 관련 이슈
- closes #[issue number]

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the MySQL Docker image version used in test environments.
  - Improved test reliability by ensuring the MySQL container is fully ready before tests begin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->