### PR TITLE
chore : CI Script 에 이미지 태그 관련 step 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,37 @@ jobs:
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           # echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+      - name : Checkout k8s repository
+        uses : actions/checkout@v4
+        with:
+          repository : GCU-Home-Protector/home-protector-infra
+          ref : main
+          token : ${{secrets.ACTION_TOKEN}}
+          path : home-protector-infra
+
+      - name : Update backend image
+        if : success()
+        run : |
+          cd home-protector-infra/overlays/develop/backend
+          sed -i 's|image: 637423458012.dkr.ecr.ap-northeast-2.amazonaws.com/home-protector.*|image: 637423458012.dkr.ecr.ap-northeast-2.amazonaws.com/home-protector:${{ github.sha }}|' patch-image.yaml
+          cat patch-image.yaml
+
+      - name : Push updated manifest
+        run : |
+          cd home-protector-infra
+          
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "github-actions"
+          
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git add overlays/develop/backend/patch-image.yaml
+            git commit -m "chore : Update backend image tag to ${{ github.sha }}"
+          else
+            echo "No changes detected, creating empty commit to trigger ArgoCD"
+            git comiit --allow-empty -m "chore : Tag update fail"
+          fi
+          
+          git push origin main
+          
+          


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
PR이 닫히고 main 에 push 될 때, ECR Image tag 가 k8s repo에 반영되도록 step 을 추가했습니다

```
      - name : Checkout k8s repository
        uses : actions/checkout@v4
        with:
          repository : GCU-Home-Protector/home-protector-infra
          ref : main
          token : ${{secrets.ACTION_TOKEN}}
          path : home-protector-infra

      - name : Update backend image
        if : success()
        run : |
          cd home-protector-infra/overlays/develop/backend
          sed -i 's|image: 637423458012.dkr.ecr.ap-northeast-2.amazonaws.com/home-protector.*|image: 637423458012.dkr.ecr.ap-northeast-2.amazonaws.com/home-protector:${{ github.sha }}|' patch-image.yaml
          cat patch-image.yaml

      - name : Push updated manifest
        run : |
          cd home-protector-infra
          
          git config --global user.email "github-actions@github.com"
          git config --global user.name "github-actions"
          
          if [[ -n "$(git status --porcelain)" ]]; then
            git add overlays/develop/backend/patch-image.yaml
            git commit -m "chore : Update backend image tag to ${{ github.sha }}"
          else
            echo "No changes detected, creating empty commit to trigger ArgoCD"
            git comiit --allow-empty -m "chore : Tag update fail"
          fi
          
          git push origin main
          
```

---

## 🔗 관련 이슈
- closes #[issue number]

---

## 💡 추가 사항