### PR TITLE
Performance/좋아요 음악 추가 및 조회 API에 Cache Aside 및 invalidation 적용

### DIFF
--- a/src/main/java/com/gachon/home_protector/HomeProtectorApplication.java
+++ b/src/main/java/com/gachon/home_protector/HomeProtectorApplication.java
@@ -6,13 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class HomeProtectorApplication {
 
+
 	public static void main(String[] args) {
-		try {
-			SpringApplication.run(HomeProtectorApplication.class, args);
-		} catch (Exception e) {
-			e.printStackTrace(); // 콘솔에 전체 예외 스택트레이스 출력
-			// 또는 로그로 남기기
-			// log.error("Spring Boot failed to start", e);
-		}
+		SpringApplication.run(HomeProtectorApplication.class, args);
 	}
 }

--- a/src/main/java/com/gachon/home_protector/domain/favorite_music/FavoriteMusic.java
+++ b/src/main/java/com/gachon/home_protector/domain/favorite_music/FavoriteMusic.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "favorite_music")
 public class FavoriteMusic extends BaseEntity {
 
     @Id

--- a/src/main/java/com/gachon/home_protector/domain/favorite_music/FavoriteMusicRepository.java
+++ b/src/main/java/com/gachon/home_protector/domain/favorite_music/FavoriteMusicRepository.java
@@ -1,5 +1,7 @@
 package com.gachon.home_protector.domain.favorite_music;
 
+import com.gachon.home_protector.domain.music.Music;
+import com.gachon.home_protector.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -9,4 +11,6 @@ public interface FavoriteMusicRepository extends JpaRepository<FavoriteMusic, Lo
 
     @Query("SELECT f FROM FavoriteMusic f WHERE f.user.id = :userId AND f.music.id = :songId")
     Optional<FavoriteMusic> findByUserAndMusicId(Long userId, Long songId);
+
+    boolean existsByUserAndMusic(User user, Music music);
 }

--- a/src/main/java/com/gachon/home_protector/domain/music/MusicController.java
+++ b/src/main/java/com/gachon/home_protector/domain/music/MusicController.java
@@ -28,9 +28,9 @@ public class MusicController {
     }
 
     @PostMapping("/likes")
-    public SuccessResponse<String> addOrDeleteFavoriteMusic(@AuthenticationPrincipal RestUserDetails userDetails,
-                                                            @Valid @RequestBody AddFavoriteMusicRequest request) {
-        return SuccessResponse.success(musicService.addOrDeleteFavoriteMusic(userDetails, request.toServiceRequest()));
+    public SuccessResponse<String> addFavoriteMusic(@AuthenticationPrincipal RestUserDetails userDetails,
+                                                    @Valid @RequestBody AddFavoriteMusicRequest request) {
+        return SuccessResponse.success(musicService.addFavoriteMusic(userDetails, request.toServiceRequest()));
     }
 
     @GetMapping("/likes")

--- a/src/main/java/com/gachon/home_protector/domain/music/MusicService.java
+++ b/src/main/java/com/gachon/home_protector/domain/music/MusicService.java
@@ -19,6 +19,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -27,6 +28,10 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MusicService {
+
+    private static final String FAVORITE_MUSIC_CACHE_KEY_PREFIX = "favoriteMusic:";
+    private static final int CACHE_BASE_TTL_SECONDS = 600;
+    private static final int CACHE_JITTER_MAX_SECONDS = 60;
 
     private final MusicRepository musicRepository;
     private final UserRepository userRepository;
@@ -51,7 +56,7 @@ public class MusicService {
 
     public List<FavoriteMusicListResponse> getFavoriteMusicList(RestUserDetails userDetails) {
         Long userId = userDetails.getId();
-        String cacheKey = "favoriteMusic:" + userId;
+        String cacheKey = FAVORITE_MUSIC_CACHE_KEY_PREFIX + userId;
 
         // 1. 캐시에서 조회
         List<FavoriteMusicListResponse> cachedList = (List<FavoriteMusicListResponse>) redisTemplate.opsForValue().get(cacheKey);
@@ -68,9 +73,8 @@ public class MusicService {
                 .toList();
 
         // 3. TTL + Jitter 설정 (예: 10분 + 0~1분)
-        int baseTtlSeconds = 600;
-        int jitterSeconds = ThreadLocalRandom.current().nextInt(0, 60);
-        redisTemplate.opsForValue().set(cacheKey, responseList, baseTtlSeconds + jitterSeconds, TimeUnit.SECONDS);
+        int jitterSeconds = ThreadLocalRandom.current().nextInt(0, CACHE_JITTER_MAX_SECONDS);
+        redisTemplate.opsForValue().set(cacheKey, responseList, CACHE_BASE_TTL_SECONDS + jitterSeconds, TimeUnit.SECONDS);
 
         return responseList;
     }
@@ -86,15 +90,21 @@ public class MusicService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException("존재하지 않는 유저입니다!"));
 
+//        boolean alreadyLiked = favoriteMusicRepository.existsByUserAndMusic(user, music);
+//        if (alreadyLiked) {
+//            return "이미 좋아요했습니다!";
+//        }
+
         FavoriteMusic favoriteMusic = FavoriteMusic.of(user, music);
         favoriteMusicRepository.save(favoriteMusic);
 
-        String cacheKey = "favoriteMusic:" + userId;
+        String cacheKey = FAVORITE_MUSIC_CACHE_KEY_PREFIX + userId;
         List<FavoriteMusicListResponse> cachedList = (List<FavoriteMusicListResponse>) redisTemplate.opsForValue().get(cacheKey);
         if (cachedList != null) {
             FavoriteMusicListResponse newFavorite = music.toFavoriteMusicListResponse();
-            cachedList.add(newFavorite);
-            redisTemplate.opsForValue().set(cacheKey, cachedList, 600 + ThreadLocalRandom.current().nextInt(60), TimeUnit.SECONDS);
+            List<FavoriteMusicListResponse> updatedList = new ArrayList<>(cachedList);
+            updatedList.add(newFavorite);
+            redisTemplate.opsForValue().set(cacheKey, updatedList, CACHE_BASE_TTL_SECONDS + ThreadLocalRandom.current().nextInt(CACHE_JITTER_MAX_SECONDS), TimeUnit.SECONDS);
         }
 
         return "좋아요를 눌렀습니다!";

--- a/src/main/java/com/gachon/home_protector/domain/music/MusicService.java
+++ b/src/main/java/com/gachon/home_protector/domain/music/MusicService.java
@@ -99,13 +99,7 @@ public class MusicService {
         favoriteMusicRepository.save(favoriteMusic);
 
         String cacheKey = FAVORITE_MUSIC_CACHE_KEY_PREFIX + userId;
-        List<FavoriteMusicListResponse> cachedList = (List<FavoriteMusicListResponse>) redisTemplate.opsForValue().get(cacheKey);
-        if (cachedList != null) {
-            FavoriteMusicListResponse newFavorite = music.toFavoriteMusicListResponse();
-            List<FavoriteMusicListResponse> updatedList = new ArrayList<>(cachedList);
-            updatedList.add(newFavorite);
-            redisTemplate.opsForValue().set(cacheKey, updatedList, CACHE_BASE_TTL_SECONDS + ThreadLocalRandom.current().nextInt(CACHE_JITTER_MAX_SECONDS), TimeUnit.SECONDS);
-        }
+        redisTemplate.delete(cacheKey);
 
         return "좋아요를 눌렀습니다!";
     }

--- a/src/main/java/com/gachon/home_protector/domain/music/MusicService.java
+++ b/src/main/java/com/gachon/home_protector/domain/music/MusicService.java
@@ -15,10 +15,13 @@ import com.gachon.home_protector.domain.user.User;
 import com.gachon.home_protector.domain.user.UserRepository;
 import com.gachon.home_protector.domain.user.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +32,7 @@ public class MusicService {
     private final UserRepository userRepository;
     private final FavoriteMusicRepository favoriteMusicRepository;
     private final MusicRecommendClient musicRecommendClient;
+    private final RedisTemplate redisTemplate;
 
     @Transactional
     public MusicRecommendResponse recommendMusic(MusicRecommendServiceRequest request) {
@@ -47,22 +51,53 @@ public class MusicService {
 
     public List<FavoriteMusicListResponse> getFavoriteMusicList(RestUserDetails userDetails) {
         Long userId = userDetails.getId();
+        String cacheKey = "favoriteMusic:" + userId;
+
+        // 1. 캐시에서 조회
+        List<FavoriteMusicListResponse> cachedList = (List<FavoriteMusicListResponse>) redisTemplate.opsForValue().get(cacheKey);
+        if (cachedList != null) {
+            return cachedList;
+        }
+
+        // 2. 캐시에 없으면 DB에서 조회
         List<Music> favoriteMusicList = musicRepository.findFavoriteMusicByUserId(userId);
         MusicAssert.validateFavoriteMusicListEmpty(favoriteMusicList, "좋아요를 누른 음악이 없습니다!");
 
-        return favoriteMusicList.stream()
+        List<FavoriteMusicListResponse> responseList = favoriteMusicList.stream()
                 .map(Music::toFavoriteMusicListResponse)
                 .toList();
+
+        // 3. TTL + Jitter 설정 (예: 10분 + 0~1분)
+        int baseTtlSeconds = 600;
+        int jitterSeconds = ThreadLocalRandom.current().nextInt(0, 60);
+        redisTemplate.opsForValue().set(cacheKey, responseList, baseTtlSeconds + jitterSeconds, TimeUnit.SECONDS);
+
+        return responseList;
     }
 
     @Transactional
-    public String addOrDeleteFavoriteMusic(RestUserDetails userDetails, AddFavoriteMusicServiceRequest serviceRequest) {
+    public String addFavoriteMusic(RestUserDetails userDetails, AddFavoriteMusicServiceRequest serviceRequest) {
         Long userId = userDetails.getId();
         Long songId = serviceRequest.getSongId();
 
-        return favoriteMusicRepository.findByUserAndMusicId(userId, songId)
-                .map(this::removeFavoriteMusic)
-                .orElseGet(() -> addFavoriteMusic(userId, songId));
+        // 1. DB에 저장
+        Music music = musicRepository.findById(songId)
+                .orElseThrow(() -> new MusicNotFoundException("존재하지 않는 음악입니다!"));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("존재하지 않는 유저입니다!"));
+
+        FavoriteMusic favoriteMusic = FavoriteMusic.of(user, music);
+        favoriteMusicRepository.save(favoriteMusic);
+
+        String cacheKey = "favoriteMusic:" + userId;
+        List<FavoriteMusicListResponse> cachedList = (List<FavoriteMusicListResponse>) redisTemplate.opsForValue().get(cacheKey);
+        if (cachedList != null) {
+            FavoriteMusicListResponse newFavorite = music.toFavoriteMusicListResponse();
+            cachedList.add(newFavorite);
+            redisTemplate.opsForValue().set(cacheKey, cachedList, 600 + ThreadLocalRandom.current().nextInt(60), TimeUnit.SECONDS);
+        }
+
+        return "좋아요를 눌렀습니다!";
     }
 
     private String addFavoriteMusic(Long userId, Long songId) {

--- a/src/main/java/com/gachon/home_protector/global/config/database/RedisClusterConfig.java
+++ b/src/main/java/com/gachon/home_protector/global/config/database/RedisClusterConfig.java
@@ -1,5 +1,7 @@
 package com.gachon.home_protector.global.config.database;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,6 +10,11 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.text.SimpleDateFormat;
 
 @Profile("dev")
 @Configuration
@@ -25,5 +32,26 @@ public class RedisClusterConfig {
         // SSL 사용 위해
         LettuceClientConfiguration lettuceClientConfiguration = LettuceClientConfiguration.builder().useSsl().disablePeerVerification().build();
         return new LettuceConnectionFactory(redisStandaloneConfiguration, lettuceClientConfiguration);
+    }
+
+
+    @Bean
+    public ObjectMapper objectMapperWithAuditing() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .setDateFormat(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"));
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory, ObjectMapper objectMapperWithAuditing) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+        GenericJackson2JsonRedisSerializer serializer =
+                new GenericJackson2JsonRedisSerializer(objectMapperWithAuditing);
+
+        redisTemplate.setConnectionFactory(connectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(serializer);
+        return redisTemplate;
     }
 }

--- a/src/main/java/com/gachon/home_protector/global/config/database/RedisConfig.java
+++ b/src/main/java/com/gachon/home_protector/global/config/database/RedisConfig.java
@@ -1,13 +1,20 @@
 package com.gachon.home_protector.global.config.database;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
-@Profile({"local, test"})
+import java.text.SimpleDateFormat;
+
+@Profile({"local", "test"})
 @Configuration
 public class RedisConfig {
 
@@ -20,5 +27,25 @@ public class RedisConfig {
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public ObjectMapper objectMapperWithAuditing() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .setDateFormat(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"));
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory, ObjectMapper objectMapperWithAuditing) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+        GenericJackson2JsonRedisSerializer serializer =
+                new GenericJackson2JsonRedisSerializer(objectMapperWithAuditing);
+
+        redisTemplate.setConnectionFactory(connectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(serializer);
+        return redisTemplate;
     }
 }

--- a/src/test/java/com/gachon/home_protector/music/MusicControllerTest.java
+++ b/src/test/java/com/gachon/home_protector/music/MusicControllerTest.java
@@ -77,7 +77,7 @@ class MusicControllerTest extends ControllerTestSupport {
     @WithMockUser(roles = "USER")
     @DisplayName("음악 좋아요를 누르거나 취소할 수 있다.")
     @Test
-    void addOrDeleteFavoriteMusic() throws Exception {
+    void addFavoriteMusic() throws Exception {
         // given
         Long songId = 1L;
         AddFavoriteMusicRequest request = new AddFavoriteMusicRequest(songId);
@@ -96,7 +96,7 @@ class MusicControllerTest extends ControllerTestSupport {
     @WithMockUser(roles = "USER")
     @DisplayName("음악 좋아요를 누르거나 취소할 때 PK의 값은 NULL이면 안 된다.")
     @Test
-    void addOrDeleteFavoriteMusic_NULL() throws Exception {
+    void addFavoriteMusic_NULL() throws Exception {
         // given
         Long songId = null;
         AddFavoriteMusicRequest request = new AddFavoriteMusicRequest(songId);
@@ -115,7 +115,7 @@ class MusicControllerTest extends ControllerTestSupport {
     @WithMockUser(roles = "USER")
     @DisplayName("음악 좋아요를 누르거나 취소할 때 PK의 값은 1 이상이여야 한다")
     @Test
-    void addOrDeleteFavoriteMusic_POSITIVE() throws Exception {
+    void addFavoriteMusic_POSITIVE() throws Exception {
         // given
         Long songId = 0L;
         AddFavoriteMusicRequest request = new AddFavoriteMusicRequest(songId);

--- a/src/test/java/com/gachon/home_protector/music/MusicServiceTest.java
+++ b/src/test/java/com/gachon/home_protector/music/MusicServiceTest.java
@@ -14,6 +14,7 @@ import com.gachon.home_protector.domain.user.User;
 import com.gachon.home_protector.domain.user.UserRepository;
 import com.gachon.home_protector.domain.user.dto.login.RestUserLoginResponse;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -116,7 +117,7 @@ class MusicServiceTest extends IntegrationTestSupport {
 
     @DisplayName("특정 음악에 대해 좋아요를 누를 수 있다.")
     @Test
-    void addOrDeleteFavoriteMusic_LIKE_NORMAL() {
+    void addFavoriteMusic_LIKE_NORMAL() {
         // given
         String userId = "userId";
         String password = "password";
@@ -138,16 +139,17 @@ class MusicServiceTest extends IntegrationTestSupport {
         AddFavoriteMusicServiceRequest request = new AddFavoriteMusicServiceRequest(musics.get(0).getId());
 
         // when
-        String result = musicService.addOrDeleteFavoriteMusic(restUserDetails, request);
+        String result = musicService.addFavoriteMusic(restUserDetails, request);
 
         // then
         assertThat(favoriteMusicRepository.findAll()).hasSize(1);
         assertThat(result).isEqualTo("좋아요를 눌렀습니다!");
     }
 
+    @Disabled
     @DisplayName("특정 음악에 대해 좋아요를 취소할 수 있다.")
     @Test
-    void addOrDeleteFavoriteMusic_LIKE_CANCEL_NORMAL() {
+    void addFavoriteMusic_LIKE_CANCEL_NORMAL() {
         // given
         String userId = "userId";
         String password = "password";
@@ -172,7 +174,7 @@ class MusicServiceTest extends IntegrationTestSupport {
         AddFavoriteMusicServiceRequest request = new AddFavoriteMusicServiceRequest(musics.get(0).getId());
 
         // when
-        String result = musicService.addOrDeleteFavoriteMusic(restUserDetails, request);
+        String result = musicService.addFavoriteMusic(restUserDetails, request);
 
         // then
         assertThat(favoriteMusicRepository.findAll()).isEmpty();


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
좋아요 음악 추가 및 조회 API에 Cache Aside 및 Write Through를 적용했습니다

---

## 🔗 관련 이슈
- closes #33 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 즐겨찾기 음악 목록에 대해 Redis 캐싱이 도입되어, 더 빠른 조회가 가능합니다.
  * 즐겨찾기 음악 추가 시 캐시가 자동으로 갱신됩니다.
  * 즐겨찾기 음악 존재 여부를 직접 확인하는 기능이 추가되었습니다.

* **버그 수정**
  * 즐겨찾기 음악 추가 기능이 명확히 분리되어, 이제는 추가만 지원합니다.

* **테스트**
  * 즐겨찾기 음악 관련 테스트 메서드 명칭이 변경되어 가독성이 향상되었습니다.
  * 불필요한 토글 테스트는 비활성화 처리되었습니다.

* **기타**
  * 데이터베이스 테이블 매핑이 명확해졌으며, Redis 설정이 개선되어 날짜/시간 데이터 처리가 일관성 있게 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->